### PR TITLE
各記事をコンポーネント化

### DIFF
--- a/components/Item.vue
+++ b/components/Item.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="w-full my-3 py-2 bg-white overflow-hidden shadow-lg">
+    <div 
+      class="mb-3 w-full h-64 bg-center bg-cover"
+      :style=" 'background-image: url(' + work.fields.image.fields.file.url + ')' "
+    ></div>
+    <h3 class="ml-3 font-bold">{{ work.fields.title }}</h3>
+    <h4 class="ml-3 my-2 text-xs">{{ work.fields.subtitle }}</h4>
+    <div class="flex ml-2">
+      <li 
+        v-for="tag in work.fields.tag"
+        :key="tag.sys.id"
+        class="list-none text-xs m-1 bg-gray-200 p-1 rounded cursor-pointer"
+      >
+        {{ tag.fields.name }}
+      </li>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: [
+    'work'
+  ]
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,36 +1,23 @@
 <template>
   <div>
-    <div 
+    <Item
       v-for="work in works"
       :key="work.sys.id"
-      class="w-full m-2 pb-3 bg-white overflow-hidden shadow-lg"
-    >
-      <div class="absolute bg-white py-1 px-3 rounded shadow mt-1 ml-1 text-sm">
-        {{ work.fields.category.fields.name }}
-      </div>
-      <div 
-        class="mb-3 w-full h-64 bg-center bg-cover"
-        :style=" 'background-image: url(' + work.fields.image.fields.file.url + ')' "
-      ></div>
-      <h3 class="ml-3 font-bold">{{ work.fields.title }}</h3>
-      <h4 class="ml-3 my-2 text-xs">{{ work.fields.subtitle }}</h4>
-      <div class="flex ml-2">
-        <li 
-          v-for="tag in work.fields.tag"
-          :key="tag.sys.id"
-          class="list-none text-xs m-1 bg-gray-200 p-1 rounded"
-        >
-          {{ tag.fields.name }}
-        </li>
-      </div>
-    </div>
+      :work="work"
+      />
   </div>
 </template>
 
 <script>
-import { createClient } from '~/plugins/contentful.js'
+import { createClient } from '~/plugins/contentful.js';
+import Item from '~/components/Item';
+
 const client = createClient()
-export default { 
+export default {
+  components: {
+    Item,
+  },
+
   asyncData() {
     return Promise.all([
       client.getEntries({


### PR DESCRIPTION
目的
・各記事をコンポーネント化
実装
・index.vueに全ての処理を書くのは効率がよくないのでItem.vueにコンポーネントとして分ける