### PR TITLE
categoryページ作成

### DIFF
--- a/components/Item.vue
+++ b/components/Item.vue
@@ -1,5 +1,10 @@
 <template>
   <div class="w-full my-3 py-2 bg-white overflow-hidden shadow-lg">
+    <nuxt-link :to=" '/category/' + work.fields.category.sys.id ">
+      <div class="absolute bg-white py-1 px-3 rounded shadow mt-1 ml-1 text-sm">
+        {{ work.fields.category.fields.name }}
+      </div>
+    </nuxt-link>
     <div 
       class="mb-3 w-full h-64 bg-center bg-cover"
       :style=" 'background-image: url(' + work.fields.image.fields.file.url + ')' "

--- a/pages/category/_id.vue
+++ b/pages/category/_id.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <Item 
+      v-for="work in works" 
+      :key="work.sys.id"
+      :work="work"
+    />
+  </div>
+</template>
+
+<script>
+import Item from '~/components/Item'
+import { createClient } from '~/plugins/contentful.js'
+const client = createClient()
+export default {
+  components: {
+    Item
+  },
+  asyncData ({params}) {
+    return Promise.all([
+      client.getEntries({
+        'content_type': 'work',
+        // idをパラメーターにして特定のカテゴリーを取得する
+        // slugを使えないのはcontentfulの仕様
+        'fields.category.sys.id': params.id,
+        order: '-sys.createdAt'
+      }),
+    ]).then(([works]) => {
+      return {
+        works: works.items
+      }
+    }).catch(console.error)
+  }
+}
+</script>

--- a/pages/work/_slug.vue
+++ b/pages/work/_slug.vue
@@ -4,6 +4,9 @@
       class="w-full h-64 my-6 bg-cover bg-center shadow-lg"
       :style=" 'background-image: url(' + work.fields.image.fields.file.url + ')' "
     ></div>
+    <nuxt-link :to=" '/category/' + work.fields.category.sys.id ">
+      <p class="text-center">{{ work.fields.category.fields.name }}</p>
+    </nuxt-link>
     <h1 class="text-center text-4xl">{{ work.fields.title }}</h1>
     <p class="text-center text-sm">{{ work.fields.subtitle }}</p>
     <div class="flex justify-center mb-5">


### PR DESCRIPTION
目的
・categoryページ作成
実装
・idをパラメーターにして特定のcategoryをもつ記事を一覧表示させるカテゴリーページに遷移
・categoryはサムネイル上部に配置