### PR TITLE
tagページ作成

### DIFF
--- a/components/Item.vue
+++ b/components/Item.vue
@@ -19,6 +19,7 @@
         v-for="tag in work.fields.tag"
         :key="tag.sys.id"
         class="list-none text-xs m-1 bg-gray-200 p-1 rounded cursor-pointer"
+        @click="$router.push('/tag/'+tag.sys.id)"
       >
         {{ tag.fields.name }}
       </li>

--- a/pages/tag/_id.vue
+++ b/pages/tag/_id.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <Item 
+      v-for="work in works" 
+      :key="work.sys.id"
+      :work="work"
+    />
+  </div>
+</template>
+
+<script>
+import Item from '~/components/Item'
+import { createClient } from '~/plugins/contentful.js'
+const client = createClient()
+export default {
+  components: {
+    Item
+  },
+  asyncData ({params}) {
+    return Promise.all([
+      client.getEntries({
+        'content_type': 'work',
+        // idをパラメーターにして特定のカテゴリーを取得する
+        // slugを使えないのはcontentfulの仕様
+        'fields.tag.sys.id': params.id,
+        order: '-sys.createdAt'
+      }),
+    ]).then(([works]) => {
+      return {
+        works: works.items
+      }
+    }).catch(console.error)
+  }
+}
+</script>

--- a/pages/work/_slug.vue
+++ b/pages/work/_slug.vue
@@ -14,6 +14,7 @@
         v-for="tag in work.fields.tag"
         :key="tag.sys.id"
         class="list-none text-xs m-1 bg-gray-200 p-1 rounded"
+        @click="$router.push('/tag/'+tag.sys.id)"
       >
         {{ tag.fields.name }}
       </li>


### PR DESCRIPTION
目的
・tagページ作成
実装
・categoryページ同様、特定のtagをもつ記事を一覧で表示する
・ページ遷移はclickイベントにしている